### PR TITLE
Removed unsupported compound operators

### DIFF
--- a/syntaxes/vba.json
+++ b/syntaxes/vba.json
@@ -111,7 +111,7 @@
     },
     {
       "match":
-        "(?i:\\s*\\b(Call|Class|Const|Dim|Redim|Function|Sub|Private Sub|Public Sub|End sub|End Function|Set|Let|Get|New|Randomize|Option Explicit|On Error Resume Next|On Error GoTo|ByRef|ByVal|Public Function|Private Function|Preserve)\\b\\s*)",
+        "(?i:\\s*\\b(Call|Const|Dim|ReDim|Function|Sub|Private Sub|Public Sub|End sub|End Function|Set|Let|Get|New|Randomize|Option Explicit|On Error Resume Next|On Error GoTo|ByRef|ByVal|Public Function|Private Function|Preserve)\\b\\s*)",
       "name": "storage.type.asp"
     },
     {
@@ -214,7 +214,7 @@
     },
     {
       "match":
-        "!|\\$|%|&|\\*|\\-\\-|\\-|\\+\\+|\\+|~|===|==|=|!=|!==|<=|>=|<<=|>>=|>>>=|<>|<|>|!|&&|\\|\\||\\?\\:|\\*=|/=|%=|\\+=|\\-=|&=|\\^=|\\b(in|instanceof|new|delete|typeof|void)\\b",
+        "!|\\$|%|&|=|<=|>=|<>|<|>|!|^|&&|\\|\\b(mod|in|new|delete|typeof)\\b",
       "name": "keyword.operator.js"
     }
   ],


### PR DESCRIPTION
Can't test, but `Class`, `void`, and `InstanceOf` aren't a thing in VBA, and compound operators aren't supported either.

This pull request removes them from `vba.json`, but I'm not sure what "storage.type.asp" is referring to, or why there are multiple lists of keywords.

Ref. #8; let me know where & how the full token list should be broken down, and I'll add a commit that adds everything that's missing (I'm a bit confused about the structure of things in that .json file).

Not sure how maintained this project is (doesn't seem very active), so I'll just leave this here and allow edits from maintainers.