### PR TITLE
Multi-line comments, adding missed keywords + adding a snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,12 @@ https://YOUR_USER_NAME.visualstudio.com/_details/security/tokens
 Some good documentation on the CLI:
 
 https://vscode-docs.readthedocs.io/en/latest/tools/vscecli/
+
+## Version history
+
+```
+20200405 - Added basic If snippet.
+20200405 - Multi-line comment capability
+20200405 - Added certain keywords e.g. Type, Enum, Implements, Optional, Friend, ... Also changed behavior of some keywords, e.g. "End","Function","Sub" instead of "End Function", "End Sub" etc..
+20200405 - Removal of non-vba behavior.
+```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ https://vscode-docs.readthedocs.io/en/latest/tools/vscecli/
 ## Version history
 
 ```
-20200405 - Added basic If snippet.
+20200405 - Added basic If snippet, and changed all snippets to use tabs (for user customisation capability).
 20200405 - Multi-line comment capability
 20200405 - Added certain keywords e.g. Type, Enum, Implements, Optional, Friend, ... Also changed behavior of some keywords, e.g. "End","Function","Sub" instead of "End Function", "End Sub" etc..
 20200405 - Removal of non-vba behavior.

--- a/snippets/vba.json
+++ b/snippets/vba.json
@@ -53,11 +53,11 @@
     "prefix": "Ife",
     "body": [
       "If ${1:expression} Then",
-      "    ",
+      "\t",
       "ElseIf ${1:expression} Then",
-      "    ",
+      "\t",
       "Else",
-      "    ",
+      "\t",
       "End If"
     ],
     "description": "If ElseIf Else code block"
@@ -66,7 +66,7 @@
     "prefix": "If",
     "body": [
       "If ${1:expression} Then",
-      "    ",
+      "\t",
       "End If"
     ],
     "description": "If ElseIf Else code block"
@@ -75,29 +75,29 @@
     "prefix": "ForE",
     "body": [
       "For Each ${1:element} In ${2:group} ",
-      "    ",
+      "\t",
       "Next ${1:element}"
     ],
     "description": "For Each code block"
   },
   "DoLoopw": {
     "prefix": "DoLoopw",
-    "body": ["Do", "    ", "Exit Do", "    ", "Loop While"],
+    "body": ["Do", "\t", "Exit Do", "\t", "Loop While"],
     "description": "Do Loop While code block"
   },
   "DoLoopu": {
     "prefix": "DoLoopu",
-    "body": ["Do", "    ", "    Exit Do", "    ", "Loop Until"],
+    "body": ["Do", "\t", "    Exit Do", "\t", "Loop Until"],
     "description": "Do Loop Until code block"
   },
   "DoWhile": {
     "prefix": "DoWhile",
-    "body": ["Do While ${1:condition}", "    ", "Loop"],
+    "body": ["Do While ${1:condition}", "\t", "Loop"],
     "description": "Do While Loop code block"
   },
   "DoUntil": {
     "prefix": "DoUntil",
-    "body": ["Do Until ${1:condition}", "    ", "Loop"],
+    "body": ["Do Until ${1:condition}", "\t", "Loop"],
     "description": "Do Until Loop code block"
   },
   "Suberr": {

--- a/snippets/vba.json
+++ b/snippets/vba.json
@@ -62,6 +62,15 @@
     ],
     "description": "If ElseIf Else code block"
   },
+  "If2": {
+    "prefix": "If",
+    "body": [
+      "If ${1:expression} Then",
+      "    ",
+      "End If"
+    ],
+    "description": "If ElseIf Else code block"
+  },
   "ForEach": {
     "prefix": "ForE",
     "body": [

--- a/syntaxes/vba.json
+++ b/syntaxes/vba.json
@@ -53,40 +53,26 @@
       ]
     },
     {
-      "captures": {
-        "1": {
-          "name": "storage.type.function.asp"
-        },
-        "2": {
-          "name": "entity.name.function.asp"
-        },
-        "3": {
-          "name": "punctuation.definition.parameters.asp"
-        },
-        "4": {
-          "name": "variable.parameter.function.asp"
-        },
-        "5": {
-          "name": "punctuation.definition.parameters.asp"
-        }
+      "comment":"This particular syntax allows for multi-line comments with _",
+      "begin": "'|(?i:rem)",
+      "beginCaptures": {
+        "0": { "name": "COMMENT_OPEN" }
       },
-      "match":
-        "^\\s*((?i:function|sub|public sub|private sub|public function|private function))\\s*([a-zA-Z_]\\w*)\\s*(\\()([^)]*)(\\)).*\\n?",
-      "name": "meta.function.asp"
-    },
-    {
-      "begin": "('|(?i:Rem)\\s{1,})",
-      "beginCaptures": [
+      "end":"\\n",
+      "endCaptures": { 
+        "0": {"name": "END_COMMENT"}
+      },
+      "name": "comment.line.apostrophe.asp",
+      "patterns": [
         {
-          "name": "punctuation.definition.comment.asp"
+          "match": "\\s_\\s*\\n",
+          "name": "comment.line.escape.apostrophe.asp"
         }
-      ],
-      "end": "(?=(\\n|%>))",
-      "name": "comment.line.apostrophe.asp"
+      ]
     },
     {
       "match":
-        "(?i:\\b(If|Then|Else|ElseIf|Else If|End If|While|Wend|For|To|Each|In|Step|Case|Select|End Select|Return|Continue|Do|Until|Loop|Next|With|End With|Exit Do|Exit For|Exit Function|Exit Property|Exit Sub|IIf)\\b)",
+        "(?i:\\b(If|Then|Else|ElseIf|End If|While|Wend|For|To|Each|In|Step|Case|Select|End Select|Return|Continue|Do|Until|Loop|Next|With|End With|Exit Do|Exit For|Exit Function|Exit Property|Exit Sub|IIf)\\b)",
       "name": "keyword.control.asp"
     },
     {
@@ -111,11 +97,11 @@
     },
     {
       "match":
-        "(?i:\\s*\\b(Call|Const|Dim|ReDim|Function|Sub|Private Sub|Public Sub|End sub|End Function|Set|Let|Get|New|Randomize|Option Explicit|On Error Resume Next|On Error GoTo|ByRef|ByVal|Public Function|Private Function|Preserve)\\b\\s*)",
+        "(?i:\\s*\\b(Const|Dim|As|ReDim|Function|Sub|End|Enum|Type|Public|Private|Friend|Implements|Call|Set|Let|Get|New|Randomize|Option Explicit|On Error Resume Next|On Error GoTo|ByRef|ByVal|Public Function|Private Function|Preserve)\\b\\s*)",
       "name": "storage.type.asp"
     },
     {
-      "match": "(?i:\\b(Private|Public|Default)\\b)",
+      "match": "(?i:\\b(Private|Public|Optional)\\b)",
       "name": "storage.modifier.asp"
     },
     {


### PR DESCRIPTION
* Multi-line comment capability (fixing #7)
* Added certain keywords e.g. Type, Enum, Implements, Optional, Friend,
* Also changed behaviour of some keywords, e.g. "End","Function","Sub"
instead of "End Function", "End Sub" etc..
* Removal of non-vba behaviour (remnants from VBScript)
* Added basic If snippet, and changed all snippets to use tabs (for user customisation capability).