### PR TITLE
Comment with REM

### DIFF
--- a/syntaxes/vba.json
+++ b/syntaxes/vba.json
@@ -54,7 +54,7 @@
     },
     {
       "comment":"This particular syntax allows for multi-line comments with _",
-      "begin": "'|(?i:(\\s)*rem\\b)",
+      "begin": "'|(?i:(?<=(:|^)(\\s)*)rem\\b)",
       "beginCaptures": {
         "0": { "name": "COMMENT_OPEN" }
       },

--- a/syntaxes/vba.json
+++ b/syntaxes/vba.json
@@ -54,7 +54,7 @@
     },
     {
       "comment":"This particular syntax allows for multi-line comments with _",
-      "begin": "'|(?i:rem)",
+      "begin": "'|(?i:(\\s)*rem\\b)",
       "beginCaptures": {
         "0": { "name": "COMMENT_OPEN" }
       },


### PR DESCRIPTION
A Line that starts with spaces and tabs then follows word "REM" should be shown as comment.

fix #11