### PR TITLE
add "Show all Symbol Definitions Within a Document" feature

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+    "root": true,
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "@typescript-eslint"
+    ],
+    "rules": {
+        "@typescript-eslint/class-name-casing": "warn",
+        "@typescript-eslint/semi": "warn",
+        "curly": "warn",
+        "eqeqeq": "warn",
+        "no-throw-literal": "warn",
+        "semi": "off"
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+out
+node_modules
+.vscode-test/
 *.vsix
+package-lock.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"dbaeumer.vscode-eslint"
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,13 +1,36 @@
 // A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-  "version": "0.1.0",
-  "configurations": [
-    {
-      "name": "Launch Extension",
-      "type": "extensionHost",
-      "request": "launch",
-      "runtimeExecutable": "${execPath}",
-      "args": ["--extensionDevelopmentPath=${workspaceRoot}"]
-    }
-  ]
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Run Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "${defaultBuildTask}"
+		},
+		{
+			"name": "Extension Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/test/**/*.js"
+			],
+			"preLaunchTask": "${defaultBuildTask}"
+		}
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true // set this to false to include "out" folder in search results
+    },
+    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+    "typescript.tsc.autoDetect": "off"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "watch",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "type": "git",
     "url": "https://github.com/spences10/vscode-vba.git"
   },
+  "activationEvents": [
+    "onLanguage:vba"
+  ],
+  "main": "./out/extension.js",
   "contributes": {
     "languages": [
       {
@@ -47,5 +51,26 @@
         "path": "./snippets/vba.json"
       }
     ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "lint": "eslint src --ext ts",
+    "watch": "tsc -watch -p ./",
+    "pretest": "npm run compile && npm run lint",
+    "test": "node ./out/test/runTest.js"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.47.0",
+    "@types/glob": "^7.1.1",
+    "@types/mocha": "^7.0.2",
+    "@types/node": "^13.11.0",
+    "eslint": "^6.8.0",
+    "@typescript-eslint/parser": "^2.30.0",
+    "@typescript-eslint/eslint-plugin": "^2.30.0",
+    "glob": "^7.1.6",
+    "mocha": "^7.1.2",
+    "typescript": "^3.8.3",
+    "vscode-test": "^1.3.0"
   }
 }

--- a/src/documentSymbolProvider.ts
+++ b/src/documentSymbolProvider.ts
@@ -1,0 +1,35 @@
+// Reference:
+//   https://code.visualstudio.com/api/language-extensions/programmatic-language-features#show-all-symbol-definitions-within-a-document
+//   https://github.com/Gimly/vscode-fortran/blob/229cddce53a2ea0b93032619efeef26376cd0d2c/src/documentSymbolProvider.ts
+import vscode = require('vscode');
+
+export class VbaDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
+
+    public provideDocumentSymbols(
+        document: vscode.TextDocument,
+        token: vscode.CancellationToken): vscode.SymbolInformation[] {
+
+        console.log('VbaDocumentSymbolProvider.provideDocumentSymbols');
+        // [Public | Private | Friend] [Static] Function name [(arglist)] [As type]
+        // [Public | Private | Friend] [Static] Sub name [(arglist)]
+        const functionRegex = /^\s*((Public|Private|Friend)\s+)?((Static)\s+)?(Function|Sub)\s+(\w+)/i;
+
+        const result: vscode.SymbolInformation[] = [];
+
+        for (let line = 0; line < document.lineCount; line++) {
+            var text = document.lineAt(line);
+            let matches = text.text.match(functionRegex);
+            if (matches) {
+                result.push(
+                    new vscode.SymbolInformation(
+                        matches[6],
+                        vscode.SymbolKind.Function,
+                        '',
+                        new vscode.Location(document.uri, text.range)
+                    ));
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,19 @@
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+import * as vscode from 'vscode'; 
+import { VbaDocumentSymbolProvider } from './documentSymbolProvider';
+
+// this method is called when your extension is activated
+// your extension is activated the very first time the command is executed
+export function activate(context: vscode.ExtensionContext) {
+
+	// Use the console to output diagnostic information (console.log) and errors (console.error)
+	// This line of code will only be executed once when your extension is activated
+	console.log('Congratulations, your extension "vba" is now active!'); 
+
+	context.subscriptions.push(
+		vscode.languages.registerDocumentSymbolProvider(
+			'vba', new VbaDocumentSymbolProvider()
+		)
+	);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "es6",
+		"outDir": "out",
+		"lib": [
+			"es6"
+		],
+		"sourceMap": true,
+		"rootDir": "src",
+		"strict": true   /* enable all strict type-checking options */
+		/* Additional Checks */
+		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+	},
+	"exclude": [
+		"node_modules",
+		".vscode-test"
+	]
+}


### PR DESCRIPTION
I implemented DocumentSymbolProvider to support [Show all Symbol Definitions Within a Document](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#show-all-symbol-definitions-within-a-document) feature.

This also enables [Outline view](https://code.visualstudio.com/updates/v1_25#_outline-view). I have been looking for this feature.
I hope you like it, too and merge this into your great extension.

src/documentSymbolProvider.ts implements DocumentSymbolProvider.  Other changes and added files are boilerplate for a typescript extension made by the Extension Generator (https://code.visualstudio.com/api/get-started/your-first-extension).

This is my first VS-code extension, transcript programming, git, and GitHub experience.  Let me know if I am missing anything.